### PR TITLE
Makefile: add back copyright and license

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,28 @@
 #!/usr/bin/make -f
+#
+# Copyright (c) 2010-2012 Dream Multimedia GmbH, Germany
+#                         http://www.dream-multimedia-tv.de/
+# Authors:
+#   Andreas Oberritter <obi@opendreambox.org>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
 
 # Adjust according to the number CPU cores to use for parallel build.
 # Default: Number of processors in /proc/cpuinfo, if present, or 1.


### PR DESCRIPTION
Dear oe-alliance developers,

your Makefile is a fork of the opendreambox Makefile with copyright information
and license terms removed - which is a violation of this license (MIT).

For your reference, here's the first published version of the original Makefile I wrote for opendreambox 2.0:
http://git.opendreambox.org/?p=opendreambox.git;a=blob;f=Makefile;h=44f7e8790b77cff86d737d957b92595a9c03cf36;hb=06c139ede3555f59b051917b599133cc9fae033f

And this is the first commit of oe-alliance, which landed about one month later:
https://github.com/oe-alliance/build-enviroment/blob/2d104e7a25f7cde4adecd00c14b77fe8739e951c/Makefile

Best regards,
Andreas