### PR TITLE
OE-core - package_manager.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -883,6 +883,12 @@ initialize: init
 init: setupmbuild $(BBLAYERS) $(CONFFILES)
 
 image: init
+	@if grep "#temporary OE-core rootfs fix" openembedded-core/meta/lib/oe/package_manager.py > /dev/null; \
+	then \
+	echo 'OE-core already patched, skipping ...'; \
+	else \
+	patch -p1 < oe-core-package_manager-temp.patch; \
+	fi
 	@. $(TOPDIR)/env.source && cd $(TOPDIR) && bitbake $(DISTRO)-image
 
 clean:

--- a/oe-core-package_manager-temp.patch
+++ b/oe-core-package_manager-temp.patch
@@ -1,0 +1,12 @@
+--- ./openembedded-core/meta/lib/oe/package_manager.py
++++ ./openembedded-core/meta/lib/oe/package_manager.py
+@@ -1348,6 +1348,9 @@ class OpkgPM(OpkgDpkgPM):
+                                               (cmd, e.returncode, e.output.decode("utf-8")))
+ 
+     def remove(self, pkgs, with_dependencies=True):
++        #temporary OE-core rootfs fix
++        if len(pkgs) == 0:
++            return
+         if with_dependencies:
+             cmd = "%s %s --force-remove --force-removal-of-dependent-packages remove %s" % \
+                 (self.opkg_cmd, self.opkg_args, ' '.join(pkgs))


### PR DESCRIPTION
- temporary workaround for mistake at do_rootfs as suggested by @atvcaptain
- see https://bugzilla.yoctoproject.org/show_bug.cgi?id=12900
- this way we can react on future cases, to time until openembedded responds to bugs