### PR TITLE
Remove bash extension from env.source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -988,16 +988,16 @@ $(TOPDIR)/env.source: $(DEPDIR)/.env.source.$(BITBAKE_ENV_HASH)
 	@echo 'export DISTRO=$(DISTRO)' >> $@
 	@echo 'export MACHINEBUILD=$(MACHINEBUILD)' >> $@
 	@echo 'export PATH=$(CURDIR)/openembedded-core/scripts:$(CURDIR)/bitbake/bin:$${PATH}' >> $@
-	@echo 'if [[ $$BB_NO_NETWORK -eq 1 ]]; then' >> $@
+	@echo 'if [ "$$BB_NO_NETWORK" = "1" ]; then' >> $@
 	@echo ' export BB_SRCREV_POLICY="cache"' >> $@
-	@echo ' echo -e "\e[95mforced offline mode\e[0m"' >> $@
+	@echo ' echo "\e[95mforced offline mode\e[0m"' >> $@
 	@echo 'else' >> $@
-	@echo ' echo -n -e "check internet connection: \e[93mWaiting ...\e[0m"' >> $@
+	@echo ' echo -n "check internet connection: \e[93mWaiting ...\e[0m"' >> $@
 	@echo ' wget -q --tries=10 --timeout=$(ONLINECHECK_TIMEOUT) --spider $(ONLINECHECK_URL)' >> $@
-	@echo ' if [[ $$? -eq 0 ]]; then' >> $@
-	@echo '  echo -e "\b\b\b\b\b\b\b\b\b\b\b\e[32mOnline      \e[0m"' >> $@
+	@echo ' if [ $$? -eq 0 ]; then' >> $@
+	@echo '  echo "\b\b\b\b\b\b\b\b\b\b\b\e[32mOnline      \e[0m"' >> $@
 	@echo ' else' >> $@
-	@echo '  echo -e "\b\b\b\b\b\b\b\b\b\b\b\e[31mOffline     \e[0m"' >> $@
+	@echo '  echo "\b\b\b\b\b\b\b\b\b\b\b\e[31mOffline     \e[0m"' >> $@
 	@echo '  export BB_SRCREV_POLICY="cache"' >> $@
 	@echo ' fi' >> $@
 	@echo 'fi' >> $@


### PR DESCRIPTION
Remove bash extension from env.source (make it sh compatible). This will make the check of online to work on build machines which do not have bash as default shell. The printout in the beginning of the build will also be nicer. In script files sh syntax should be followed and not use bash extensions.

The "-e" argument to echo have been removed. Since it was printed out. This because it is no backslash escapes in the env.source file. However I think this is a faulty behaviour of echo, but this is how echo works (at least on my machine). The make application have already taken care of the backslash escapes signs, i.e. interpret them and inserted the wanted values in the env.source file.

Test:
- Build of vuduo4k on Xubuntu 18.04 (with default shell). Check so the first row prints nice and the build works.
- The created env.source file have been manually tested. This by taken a copy of it and added "#!/bin/sh" as a first row and add execute flag to the file. Execution of the file have been done with and without BB_NO_NETWORK env variable. Script react on value 1. Also tested on/offline detection by changing the ip address to no existing name.